### PR TITLE
fix: dataset name

### DIFF
--- a/src/contratos_cessao/constants.py
+++ b/src/contratos_cessao/constants.py
@@ -3,7 +3,7 @@ URL = (
     "https://www.gov.br/anp/pt-br/assuntos/distribuicao-e-revenda/distribuidor/distr/rd-ce-cf-qe/cessao-espaco-carregamento.xlsx"
 )
 
-TABLE_ID = "raw_ext_anp.contratos_cessao_espaco_carregamento"
+TABLE_ID = "rw_ext_anp.contratos_cessao_espaco_carregamento"
 
 MAPPING_COLUMNS = {
     'TIPO DE CONTRATO': 'tipo_contrato',

--- a/src/vendas_comb_segmento/constants.py
+++ b/src/vendas_comb_segmento/constants.py
@@ -4,7 +4,7 @@ URL = (
     "https://www.gov.br/anp/pt-br/centrais-de-conteudo/dados-abertos/vendas-de-derivados-de-petroleo-e-biocombustiveis"
 )
 
-TABLE_ID = "raw_ext_anp.vendas_combustiveis_segmento"
+TABLE_ID = "rw_ext_anp.vendas_combustiveis_segmento"
 
 MAPPING_COLUMNS = {
     'ANO': 'ano',


### PR DESCRIPTION
Nome do dataset rw_ext_anp estava errado nos arquivos de constantes das fontes de contratos de cessão e de vendas de combustíveis por segmento 